### PR TITLE
Fixed out of bounds error for FuelType(MessageIndex)

### DIFF
--- a/src/RTDSimulatorDesktopApp/EventSender.cs
+++ b/src/RTDSimulatorDesktopApp/EventSender.cs
@@ -115,7 +115,8 @@ namespace RTDSimulatorDesktopApp
                 if (key == "FuelType(MessageIndex)")
                 {
                     String[] arr = val.Split("|");
-                    val = arr[msgIndex];
+                    int i = msgIndex % arr.Length; // iterate through fuel types
+                    val = arr[i];
                 }
                 payload = payload.Replace("{{" + v.Key + "}}", val);
             }


### PR DESCRIPTION
If the number of messages sent per batch exceeds 19 then an [Index was outside the bounds of the array] error is generated. This iterates through fuel types ensuring that if you have 19 messages or more you will have generated each fuel type. Future enhancement could make this so that you can select whether the fuel type is randomly generated or the iteration method.