### PR TITLE
Improve performance of C# expressions in Payload and other tweaks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,12 @@
+# Changelog - Real-Time-Data-Simulator
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [0.0.1] - 2024-06-01
+### Features
+* Added reuse of compiled C# expressions from message payload, repeated use of an expression executes faster
+* Limit use to single EventSender and Single EventHubProducerClient across all threads
+* Updated completion logic that requires all threads to complete before updating UI
+* Some tweaks to reduce locking of UI during execution

--- a/src/RTDSimulatorDesktopApp/frmGenerator.Designer.cs
+++ b/src/RTDSimulatorDesktopApp/frmGenerator.Designer.cs
@@ -139,7 +139,7 @@
             btnRun.TabIndex = 6;
             btnRun.Text = "RUN";
             btnRun.UseVisualStyleBackColor = true;
-            btnRun.Click += btnRun_Click;
+            btnRun.Click += async (sender, e) => await btnRun_Click(sender, e);
             // 
             // progressBar1
             // 

--- a/src/RTDSimulatorDesktopApp/frmGenerator.cs
+++ b/src/RTDSimulatorDesktopApp/frmGenerator.cs
@@ -71,7 +71,7 @@ namespace RTDSimulatorDesktopApp
 
         }
 
-        private void EventSender_OnCompleted()//(object? sender, EventArgs e)
+        private void EventSender_OnCompleted()
         {
             progressBar1.Maximum = progressBar1.Value;
             _EndTime = DateTime.Now;

--- a/src/RTDSimulatorDesktopApp/frmGenerator.cs
+++ b/src/RTDSimulatorDesktopApp/frmGenerator.cs
@@ -19,7 +19,6 @@ namespace RTDSimulatorDesktopApp
         private int _MsgSent = 0;
         private DateTime _StartTime = DateTime.MinValue;
         private DateTime _EndTime = DateTime.MinValue;
-        private Object _uiLocker = new object();
 
         public bool IsPayloadChanged
         {


### PR DESCRIPTION
- Added reuse of compiled C# expressions from message payload, repeated use of an expression executes faster
- Limit use to single EventSender and Single EventHubProducerClient across all threads
- Updated completion logic that requires all threads to complete before updating UI
- Some tweaks to reduce locking of UI during execution